### PR TITLE
Update 50-usb-serial.rules

### DIFF
--- a/clam_controller/setup/50-usb-serial.rules
+++ b/clam_controller/setup/50-usb-serial.rules
@@ -1,4 +1,6 @@
 # A copy of this file goes into /etc/udev/rules.d/
 # So that the usb to serial drivers are mapped reliably
-SUBSYSTEMS=="usb",DRIVERS=="ftdi_sio",ATTRS{interface}=="FT232R USB UART",SYMLINK+="dynamixel_rs485"
-SUBSYSTEMS=="usb",DRIVERS=="ftdi_sio",ATTRS{interface}=="AX12",SYMLINK+="dynamixel_ttl"
+#SUBSYSTEMS=="usb",DRIVERS=="ftdi_sio",ATTRS{interface}=="FT232R USB UART",SYMLINK+="dynamixel_rs485"
+#SUBSYSTEMS=="usb",DRIVERS=="ftdi_sio",ATTRS{interface}=="AX12",SYMLINK+="dynamixel_ttl"
+SUBSYSTEMS=="usb",DRIVERS=="ftdi_sio",KERNEL=ttyUSB0,SYMLINK+="dynamixel_rs485",MODE=777
+SUBSYSTEMS=="usb",DRIVERS=="ftdi_sio",KERNEL=ttyUSB1,SYMLINK+="dynamixel_ttl",MODE=777


### PR DESCRIPTION
The current udev rules does not allow us to identify dynamixel_ttl. We think this new rule may be more dependable.
