### PR TITLE
Updating name of gripper controller

### DIFF
--- a/clam_controller/nodes/joint_states_publisher.py.disabled
+++ b/clam_controller/nodes/joint_states_publisher.py.disabled
@@ -46,7 +46,7 @@ class JointStatesPublisher():
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
                             
         self.joint_states = {}
                              

--- a/clam_controller/scripts/gripper_close.py
+++ b/clam_controller/scripts/gripper_close.py
@@ -8,7 +8,7 @@ import rospy
 from std_msgs.msg import Float64
 
 if __name__ == '__main__':
-    pub = rospy.Publisher('l_gripper_aft_controller/command', Float64);
+    pub = rospy.Publisher('gripper_finger_controller/command', Float64);
      rospy.init_node('pose_gripper_close', anonymous=True)
     time.sleep(1)
     print "Closing gripper"

--- a/clam_controller/scripts/gripper_open.py
+++ b/clam_controller/scripts/gripper_open.py
@@ -8,7 +8,7 @@ import rospy
 from std_msgs.msg import Float64
 
 if __name__ == '__main__':
-    pub = rospy.Publisher('l_gripper_aft_controller/command', Float64);
+    pub = rospy.Publisher('gripper_finger_controller/command', Float64);
     rospy.init_node('pose_gripper_open', anonymous=True)
 
     time.sleep(1)

--- a/clam_controller/scripts/gripper_test.py
+++ b/clam_controller/scripts/gripper_test.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
         except rospy.ServiceException, e:
             print "Service call failed: %s"%e
 
-    pub = rospy.Publisher('l_gripper_aft_controller/command', Float64);
+    pub = rospy.Publisher('gripper_finger_controller/command', Float64);
     rospy.init_node('pose_gripper_close', anonymous=True)
     time.sleep(1)
     print "Testing gripper"

--- a/clam_controller/scripts/pose_animate.py
+++ b/clam_controller/scripts/pose_animate.py
@@ -14,7 +14,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
                
 joint_commands = (-1.0, 0.5, 0.7, 1.0, 1.0, 1.0, 1.0, -0.9)
 joint_commands2 = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)

--- a/clam_controller/scripts/pose_cobra.py
+++ b/clam_controller/scripts/pose_cobra.py
@@ -14,7 +14,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
                
 joint_commands = (0.0, 0.0, 0.0, 0.0, 0.0, 1.5, 0.0, -1)
 

--- a/clam_controller/scripts/pose_jaw.py
+++ b/clam_controller/scripts/pose_jaw.py
@@ -8,7 +8,7 @@ import rospy
 from std_msgs.msg import Float64
 
 if __name__ == '__main__':
-    pub = rospy.Publisher('l_gripper_aft_controller/command', Float64);
+    pub = rospy.Publisher('gripper_finger_controller/command', Float64);
     rospy.init_node('pose_jaw', anonymous=True)
 
     command = -1.0

--- a/clam_controller/scripts/pose_sleep.py
+++ b/clam_controller/scripts/pose_sleep.py
@@ -14,7 +14,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
                
 joint_commands = (0.0, 2, 0.0, -0.3, 0.0, 0.0, 0.0, 1.0)
 

--- a/clam_controller/scripts/pose_zero.py
+++ b/clam_controller/scripts/pose_zero.py
@@ -14,7 +14,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
                
 joint_commands = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 

--- a/clam_controller/scripts/sequence_play.py
+++ b/clam_controller/scripts/sequence_play.py
@@ -22,7 +22,7 @@ controller_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
                
 def main():
 

--- a/clam_controller/scripts/sequence_record.py
+++ b/clam_controller/scripts/sequence_record.py
@@ -15,7 +15,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
 
 coords = []   # store an array of coordinates over time
 

--- a/clam_controller/scripts/set_all_compliance_margin.py
+++ b/clam_controller/scripts/set_all_compliance_margin.py
@@ -14,7 +14,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
 
 
 if __name__ == '__main__':

--- a/clam_controller/scripts/set_all_compliance_slope.py
+++ b/clam_controller/scripts/set_all_compliance_slope.py
@@ -14,7 +14,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
 
 
 if __name__ == '__main__':

--- a/clam_controller/scripts/set_all_torque.py
+++ b/clam_controller/scripts/set_all_torque.py
@@ -14,7 +14,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
 
 
 if __name__ == '__main__':

--- a/clam_controller/scripts/set_all_velocity.py
+++ b/clam_controller/scripts/set_all_velocity.py
@@ -14,7 +14,7 @@ joint_names = ('shoulder_pan_controller',
                'wrist_roll_controller',
                'wrist_pitch_controller',
                'gripper_roll_controller',
-               'l_gripper_aft_controller')
+               'gripper_finger_controller')
 
 if __name__ == '__main__':
 

--- a/clam_controller/src/clam_arm_action_server_DELETE.cpp
+++ b/clam_controller/src/clam_arm_action_server_DELETE.cpp
@@ -90,9 +90,9 @@ static const double END_EFFECTOR_VELOCITY = 0.6;
 static const double END_EFFECTOR_MEDIUM_VELOCITY = 0.4;
 static const double END_EFFECTOR_SLOW_VELOCITY = 0.1;
 static const double END_EFFECTOR_LOAD_SETPOINT = -0.35; // when less than this number, stop closing. original value: -0.3
-static const std::string EE_VELOCITY_SRV_NAME = "/l_gripper_aft_controller/set_velocity";
-static const std::string EE_STATE_MSG_NAME = "/l_gripper_aft_controller/state";
-static const std::string EE_POSITION_MSG_NAME = "/l_gripper_aft_controller/command";
+static const std::string EE_VELOCITY_SRV_NAME = "/gripper_finger_controller/set_velocity";
+static const std::string EE_STATE_MSG_NAME = "/gripper_finger_controller/state";
+static const std::string EE_POSITION_MSG_NAME = "/gripper_finger_controller/command";
 
 // Constants for MoveIt
 static const std::string GROUP_NAME = "arm";

--- a/clam_interactive_markers/src/clam_marker_server.cpp
+++ b/clam_interactive_markers/src/clam_marker_server.cpp
@@ -122,7 +122,7 @@ public:
 
       joints.push_back("shoulder_pan_controller");
       joints.push_back("gripper_roll_controller");
-      joints.push_back("l_gripper_aft_controller");
+      joints.push_back("gripper_finger_controller");
       joints.push_back("shoulder_pitch_controller");
       joints.push_back("elbow_roll_controller");
       joints.push_back("elbow_pitch_controller");


### PR DESCRIPTION
It looks like the gripper controller is now called gripper_finger_controller.  This PR updates some places in the code that were still using l_gripper_aft_controller.
