### PR TITLE
fix error in gazebo simulation log

### DIFF
--- a/clam_description/urdf/clam.xacro
+++ b/clam_description/urdf/clam.xacro
@@ -562,7 +562,9 @@ http://www.ros.org/wiki/xacro
   <!-- Transmissions for ROS Control -->
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_pan_joint"/>
+    <joint name="shoulder_pan_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
@@ -571,7 +573,9 @@ http://www.ros.org/wiki/xacro
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_pitch_joint"/>
+    <joint name="shoulder_pitch_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
@@ -580,7 +584,9 @@ http://www.ros.org/wiki/xacro
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="elbow_roll_joint"/>
+    <joint name="elbow_roll_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
@@ -589,7 +595,9 @@ http://www.ros.org/wiki/xacro
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="elbow_pitch_joint"/>
+    <joint name="elbow_pitch_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
@@ -598,7 +606,9 @@ http://www.ros.org/wiki/xacro
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_roll_joint"/>
+    <joint name="wrist_roll_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
@@ -607,7 +617,9 @@ http://www.ros.org/wiki/xacro
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_pitch_joint"/>
+    <joint name="wrist_pitch_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
@@ -616,7 +628,9 @@ http://www.ros.org/wiki/xacro
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="gripper_roll_joint"/>
+    <joint name="gripper_roll_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
@@ -625,7 +639,9 @@ http://www.ros.org/wiki/xacro
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="gripper_finger_joint"/>
+    <joint name="gripper_finger_joint">
+      <hardwareInterface>EffortJointInterface</hardwareInterface>
+    </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>


### PR DESCRIPTION
When starting the clam arm in gazebo I was seeing these errors:

[ INFO] [1418878448.704485967, 0.536000000]: gazebo_ros_control plugin is waiting for model URDF in parameter [/robot_description] on the ROS param server.
[ERROR] [1418878448.806375161, 0.536000000]: No valid hardware interface element found in joint 'shoulder_pan_joint'.
[ERROR] [1418878448.806422232, 0.536000000]: Failed to load joints for transmission 'tran1'.
[ERROR] [1418878448.806444608, 0.536000000]: No valid hardware interface element found in joint 'shoulder_pitch_joint'.
[ERROR] [1418878448.806460735, 0.536000000]: Failed to load joints for transmission 'tran1'.
[ERROR] [1418878448.806478720, 0.536000000]: No valid hardware interface element found in joint 'elbow_roll_joint'.
[ERROR] [1418878448.806496745, 0.536000000]: Failed to load joints for transmission 'tran1'.
[ERROR] [1418878448.806517349, 0.536000000]: No valid hardware interface element found in joint 'elbow_pitch_joint'.
[ERROR] [1418878448.806535559, 0.536000000]: Failed to load joints for transmission 'tran1'.
[ERROR] [1418878448.806553456, 0.536000000]: No valid hardware interface element found in joint 'wrist_roll_joint'.
[ERROR] [1418878448.806573583, 0.536000000]: Failed to load joints for transmission 'tran1'.
[ERROR] [1418878448.806591797, 0.536000000]: No valid hardware interface element found in joint 'wrist_pitch_joint'.
[ERROR] [1418878448.806608606, 0.536000000]: Failed to load joints for transmission 'tran1'.
[ERROR] [1418878448.806626779, 0.536000000]: No valid hardware interface element found in joint 'gripper_roll_joint'.
[ERROR] [1418878448.806646964, 0.536000000]: Failed to load joints for transmission 'tran1'.
[ERROR] [1418878448.806664652, 0.536000000]: No valid hardware interface element found in joint 'gripper_finger_joint'.
[ERROR] [1418878448.806683746, 0.536000000]: Failed to load joints for transmission 'tran1'.
[ INFO] [1418878448.925537070, 0.536000000]: Loaded gazebo_ros_control.

which lead me here:

http://answers.ros.org/question/186681/no-valid-hardware-interface-element-found-in-joint/?answer=187192#post-id-187192

These changes seem to fix the errors.
